### PR TITLE
Added localization support

### DIFF
--- a/src/AdminOnlyProperty/AdminOnlyProperty.csproj
+++ b/src/AdminOnlyProperty/AdminOnlyProperty.csproj
@@ -1,9 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <StaticWebAssetBasePath>/</StaticWebAssetBasePath>
     <RootNamespace>Umbraco.Community.AdminOnlyProperty</RootNamespace>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageId>Our.Umbraco.Community.AdminOnlyProperty</PackageId>

--- a/src/AdminOnlyProperty/AdminOnlyPropertyConfigurationEditor.cs
+++ b/src/AdminOnlyProperty/AdminOnlyPropertyConfigurationEditor.cs
@@ -1,6 +1,7 @@
-﻿using Umbraco.Cms.Core.IO;
+using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.PropertyEditors;
 using Umbraco.Cms.Core.Services;
+using Umbraco.Extensions;
 using UmbConstants = Umbraco.Cms.Core.Constants;
 
 namespace Umbraco.Community.AdminOnlyProperty
@@ -13,6 +14,7 @@ namespace Umbraco.Community.AdminOnlyProperty
         public AdminOnlyPropertyConfigurationEditor(
             IDataTypeService dataTypeService,
             IIOHelper ioHelper,
+            ILocalizedTextService localizedTextService,
             IUserService userService,
             PropertyEditorCollection propertyEditors)
             : base()
@@ -23,8 +25,8 @@ namespace Umbraco.Community.AdminOnlyProperty
             Fields.Add(new ConfigurationField
             {
                 Key = "dataType",
-                Name = "Data type",
-                Description = "The data type to wrap.",
+                Name = localizedTextService.Localize("adminOnlyProperty", "labelDataType") ?? "Data type",
+                Description = localizedTextService.Localize("adminOnlyProperty", "descriptionDataType") ?? "The data type to wrap.",
                 View = "treepicker",
                 Config = new Dictionary<string, object>
                 {

--- a/src/AdminOnlyProperty/AdminOnlyPropertyDataEditor.cs
+++ b/src/AdminOnlyProperty/AdminOnlyPropertyDataEditor.cs
@@ -46,7 +46,7 @@ namespace Umbraco.Community.AdminOnlyProperty
 
         public EditorType Type => EditorType.PropertyValue;
 
-        public string Name => _localizedTextService.Localize("adminOnlyProperty", "packageName") ?? DataEditorName;
+        public string Name => DataEditorName;
 
         public string Icon => DataEditorIcon;
 

--- a/src/AdminOnlyProperty/AdminOnlyPropertyDataEditor.cs
+++ b/src/AdminOnlyProperty/AdminOnlyPropertyDataEditor.cs
@@ -1,9 +1,10 @@
-﻿using Umbraco.Cms.Core.IO;
+using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.PropertyEditors;
 using Umbraco.Cms.Core.Serialization;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Strings;
+using Umbraco.Extensions;
 using UmbConstants = Umbraco.Cms.Core.Constants;
 
 namespace Umbraco.Community.AdminOnlyProperty
@@ -45,7 +46,7 @@ namespace Umbraco.Community.AdminOnlyProperty
 
         public EditorType Type => EditorType.PropertyValue;
 
-        public string Name => DataEditorName;
+        public string Name => _localizedTextService.Localize("adminOnlyProperty", "packageName") ?? DataEditorName;
 
         public string Icon => DataEditorIcon;
 
@@ -62,6 +63,7 @@ namespace Umbraco.Community.AdminOnlyProperty
             return new AdminOnlyPropertyConfigurationEditor(
                 _dataTypeService,
                 _ioHelper,
+                _localizedTextService,
                 _userService,
                 _propertyEditors);
         }

--- a/src/AdminOnlyProperty/wwwroot/App_Plugins/AdminOnlyProperty/lang/da.xml
+++ b/src/AdminOnlyProperty/wwwroot/App_Plugins/AdminOnlyProperty/lang/da.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <language alias="da" intName="Danish" localName="Dansk" lcid="" culture="da-DK">
     <area alias="adminOnlyProperty">
-        <key alias="packageName">Admin Only Property</key>
         <key alias="labelDataType">Datatype</key>
         <key alias="descriptionDataType">Datatypen der skal skjules.</key>
     </area>

--- a/src/AdminOnlyProperty/wwwroot/App_Plugins/AdminOnlyProperty/lang/da.xml
+++ b/src/AdminOnlyProperty/wwwroot/App_Plugins/AdminOnlyProperty/lang/da.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<language alias="da" intName="Danish" localName="Dansk" lcid="" culture="da-DK">
+    <area alias="adminOnlyProperty">
+        <key alias="packageName">Admin Kun Ejendom</key>
+        <key alias="labelDataType">Datatype</key>
+        <key alias="descriptionDataType">Datatypen, der skal ombrydes.</key>
+    </area>
+</language>

--- a/src/AdminOnlyProperty/wwwroot/App_Plugins/AdminOnlyProperty/lang/da.xml
+++ b/src/AdminOnlyProperty/wwwroot/App_Plugins/AdminOnlyProperty/lang/da.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <language alias="da" intName="Danish" localName="Dansk" lcid="" culture="da-DK">
     <area alias="adminOnlyProperty">
-        <key alias="packageName">Admin Kun Ejendom</key>
+        <key alias="packageName">Admin Only Property</key>
         <key alias="labelDataType">Datatype</key>
         <key alias="descriptionDataType">Datatypen der skal skjules.</key>
     </area>

--- a/src/AdminOnlyProperty/wwwroot/App_Plugins/AdminOnlyProperty/lang/da.xml
+++ b/src/AdminOnlyProperty/wwwroot/App_Plugins/AdminOnlyProperty/lang/da.xml
@@ -3,6 +3,6 @@
     <area alias="adminOnlyProperty">
         <key alias="packageName">Admin Kun Ejendom</key>
         <key alias="labelDataType">Datatype</key>
-        <key alias="descriptionDataType">Datatypen, der skal ombrydes.</key>
+        <key alias="descriptionDataType">Datatypen der skal skjules.</key>
     </area>
 </language>

--- a/src/AdminOnlyProperty/wwwroot/App_Plugins/AdminOnlyProperty/lang/en.xml
+++ b/src/AdminOnlyProperty/wwwroot/App_Plugins/AdminOnlyProperty/lang/en.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<language alias="en" intName="English (UK)" localName="English (UK)" lcid="" culture="en-GB">
+    <area alias="adminOnlyProperty">
+        <key alias="packageName">Admin Only Property</key>
+        <key alias="labelDataType">Data type</key>
+        <key alias="descriptionDataType">The data type to wrap.</key>
+    </area>
+</language>

--- a/src/AdminOnlyProperty/wwwroot/App_Plugins/AdminOnlyProperty/lang/en.xml
+++ b/src/AdminOnlyProperty/wwwroot/App_Plugins/AdminOnlyProperty/lang/en.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <language alias="en" intName="English (UK)" localName="English (UK)" lcid="" culture="en-GB">
     <area alias="adminOnlyProperty">
-        <key alias="packageName">Admin Only Property</key>
         <key alias="labelDataType">Data type</key>
         <key alias="descriptionDataType">The data type to wrap.</key>
     </area>


### PR DESCRIPTION
Fixes #2

Changed the VS project type to be a Razor Class Library, (so the XML language files are embedded).

Added example localisations for English, along with a Google-translate of Danish, (please let a Danish-speaking person correct any of these).