### PR TITLE
Added allowed groups configuration

### DIFF
--- a/src/AdminOnlyProperty/AdminOnlyProperty.csproj
+++ b/src/AdminOnlyProperty/AdminOnlyProperty.csproj
@@ -36,6 +36,7 @@
 
   <ItemGroup>
     <PackageReference Include="Umbraco.Cms.Core" Version="10.2.0" />
+    <PackageReference Include="Umbraco.Cms.Web.BackOffice" Version="10.2.0" />
   </ItemGroup>
 
 </Project>

--- a/src/AdminOnlyProperty/AdminOnlyPropertyConfigurationEditor.cs
+++ b/src/AdminOnlyProperty/AdminOnlyPropertyConfigurationEditor.cs
@@ -23,6 +23,28 @@ namespace Umbraco.Community.AdminOnlyProperty
             _dataTypeService = dataTypeService;
             _propertyEditors = propertyEditors;
 
+            var groups = userService
+               .GetAllUserGroups()
+               .Select(x => new
+               {
+                   label = x.Name,
+                   value = x.Alias,
+               });
+
+            _ = DefaultConfiguration.TryAdd("userGroups", new[] { "admin" });
+
+            Fields.Add(new ConfigurationField
+            {
+                Key = "userGroups",
+                Name = "User groups",
+                Description = "Select as many user groups as you like!",
+                View = "checkboxlist",
+                Config = new Dictionary<string, object>
+                {
+                    { "prevalues", groups },
+                }
+            });
+
             Fields.Add(new ConfigurationField
             {
                 Key = "dataType",

--- a/src/AdminOnlyProperty/AdminOnlyPropertyConfigurationEditor.cs
+++ b/src/AdminOnlyProperty/AdminOnlyPropertyConfigurationEditor.cs
@@ -12,6 +12,9 @@ namespace Umbraco.Community.AdminOnlyProperty
         private readonly IDataTypeService _dataTypeService;
         private readonly PropertyEditorCollection _propertyEditors;
 
+        internal readonly string[] DefaultUserGroups = new[] { "admin" };
+        internal const string UserGroups = "userGroups";
+
         public AdminOnlyPropertyConfigurationEditor(
             IDataTypeService dataTypeService,
             IIOHelper ioHelper,
@@ -31,11 +34,11 @@ namespace Umbraco.Community.AdminOnlyProperty
                    value = x.Alias,
                });
 
-            _ = DefaultConfiguration.TryAdd("userGroups", new[] { "admin" });
+            _ = DefaultConfiguration.TryAdd(UserGroups, DefaultUserGroups);
 
             Fields.Add(new ConfigurationField
             {
-                Key = "userGroups",
+                Key = UserGroups,
                 Name = "User groups",
                 Description = "Select as many user groups as you like!",
                 View = "checkboxlist",
@@ -69,6 +72,11 @@ namespace Umbraco.Community.AdminOnlyProperty
                 obj1 is string str1 &&
                 int.TryParse(str1, out var id) == true)
             {
+                if (config.ContainsKey(UserGroups) == false)
+                {
+                    config.Add(UserGroups, DefaultUserGroups);
+                }
+
                 var dataType = _dataTypeService.GetDataType(id);
                 if (dataType != null && _propertyEditors.TryGet(dataType.EditorAlias, out var dataEditor) == true)
                 {

--- a/src/AdminOnlyProperty/AdminOnlyPropertySendingContentNotificationHandler.cs
+++ b/src/AdminOnlyProperty/AdminOnlyPropertySendingContentNotificationHandler.cs
@@ -1,4 +1,5 @@
-﻿using Umbraco.Cms.Core.Events;
+using Newtonsoft.Json.Linq;
+using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.Security;
 using Umbraco.Extensions;
@@ -29,12 +30,16 @@ namespace Umbraco.Community.AdminOnlyProperty
                             var cacheKey = $"__aopConfig";
                             if (prop?.PropertyEditor?.Alias.InvariantEquals(AdminOnlyPropertyDataEditor.DataEditorAlias) == true &&
                                 prop?.ConfigNullable.TryGetValue(cacheKey, out var tmp1) == true &&
-                                tmp1 is Dictionary<string, object> config
-                                )
+                                tmp1 is Dictionary<string, object> config &&
+                                config.TryGetValue("userGroups", out var tmp2) == true &&
+                                tmp2 is JArray array1 &&
+                                array1.Count > 0)
                             {
                                 prop.ConfigNullable.Remove(cacheKey);
 
-                                return user.IsAdmin();
+                                var allowedGroups = array1.ToObject<string[]>();
+
+                                return user.Groups.Any(x => allowedGroups?.Contains(x.Alias) == true);
                             }
 
                             return true;

--- a/src/AdminOnlyProperty/AdminOnlyPropertySendingContentNotificationHandler.cs
+++ b/src/AdminOnlyProperty/AdminOnlyPropertySendingContentNotificationHandler.cs
@@ -31,7 +31,7 @@ namespace Umbraco.Community.AdminOnlyProperty
                             if (prop?.PropertyEditor?.Alias.InvariantEquals(AdminOnlyPropertyDataEditor.DataEditorAlias) == true &&
                                 prop?.ConfigNullable.TryGetValue(cacheKey, out var tmp1) == true &&
                                 tmp1 is Dictionary<string, object> config &&
-                                config.TryGetValue("userGroups", out var tmp2) == true &&
+                                config.TryGetValue(AdminOnlyPropertyConfigurationEditor.UserGroups, out var tmp2) == true &&
                                 tmp2 is JArray array1 &&
                                 array1.Count > 0)
                             {


### PR DESCRIPTION
Fixes #1

Using Umbraco's checkboxlist prevalue-editor to list the user groups, with the default value set to "admin".

I looked at @bjarnef's https://github.com/LottePitcher/umbraco-admin-only-property/issues/1#issuecomment-1287370692, but I didn't want to introduce additional HTML/JS at this point.