### PR TITLE
Added Umbraco Deploy connector for the DataType

### DIFF
--- a/src/AdminOnlyProperty/AdminOnlyPropertyConfigurationConnector.cs
+++ b/src/AdminOnlyProperty/AdminOnlyPropertyConfigurationConnector.cs
@@ -1,0 +1,39 @@
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Deploy;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Cms.Core.Serialization;
+
+namespace Umbraco.Community.AdminOnlyProperty
+{
+    internal sealed class AdminOnlyPropertyConfigurationConnector : IDataTypeConfigurationConnector
+    {
+        private readonly IConfigurationEditorJsonSerializer _configurationEditorJsonSerializer;
+
+        public IEnumerable<string> PropertyEditorAliases => new[] { AdminOnlyPropertyDataEditor.DataEditorAlias };
+
+        public AdminOnlyPropertyConfigurationConnector(IConfigurationEditorJsonSerializer configurationEditorJsonSerializer)
+        {
+            _configurationEditorJsonSerializer = configurationEditorJsonSerializer;
+        }
+
+        public object? FromArtifact(IDataType dataType, string? configuration)
+        {
+            var dataTypeConfigurationEditor = dataType.Editor?.GetConfigurationEditor();
+            return dataTypeConfigurationEditor?.FromDatabase(configuration, _configurationEditorJsonSerializer);
+        }
+
+        public string? ToArtifact(IDataType dataType, ICollection<ArtifactDependency> dependencies)
+        {
+            if (dataType.Configuration is Dictionary<string, object> config &&
+                config.TryGetValue(AdminOnlyPropertyConfigurationEditor.DataTypeKey, out var obj1) == true &&
+                obj1 is string str1 &&
+                UdiParser.TryParse<GuidUdi>(str1, out var udi) == true)
+            {
+                dependencies.Add(new ArtifactDependency(udi, false, ArtifactDependencyMode.Match));
+            }
+
+            return ConfigurationEditor.ToDatabase(dataType.Configuration, _configurationEditorJsonSerializer);
+        }
+    }
+}


### PR DESCRIPTION
Taking inspiration from #16, I thought I'd add the basis for an Umbraco Deploy connector.
_(To note, I already had similar in my Custom ValueConverter package, [see `CustomValueConverterConfigurationConnector.cs`](https://github.com/leekelleher/umbraco-custom-valueconverter/blob/develop/src/DataEditor/CustomValueConverterConfigurationConnector.cs))_

This code will let Umbraco Deploy know that the configuration has a dependency on the selected DataType, so that it can transfer it to the target environment. _(To note, this uses the [`IDataTypeConfigurationConnector`](https://github.com/umbraco/Umbraco-CMS/blob/release-10.2.0/src/Umbraco.Core/Deploy/IDataTypeConfigurationConnector.cs) interface from Umbraco Core, so not a hard dependency on Umbraco Deploy)._

I did attempt to implement the [`IValueConnector`](https://github.com/umbraco/Umbraco-CMS/blob/release-10.2.0/src/Umbraco.Core/Deploy/IValueConnector.cs), (which is used to add any dependencies that happen at the Content Property level, e.g. think MNTP picked nodes).

But I hit a snag. From looking at how the [`NestedContentValueConnector`](https://github.com/umbraco/Umbraco.Deploy.Contrib/blob/v10/dev/src/Umbraco.Deploy.Contrib/ValueConnectors/NestedContentValueConnector.cs#L142) does it in the [Umbraco Deploy Contrib](https://github.com/umbraco/Umbraco.Deploy.Contrib) library, it uses the `ValueConnectorCollection` to run any Deploy connectors for the inner-value... and unfortunately `ValueConnectorCollection` is inside the Umbraco Deploy assemblies... meaning that if we did that, we'd have a hard dependency on Umbraco Deploy _(which we don't want to do, otherwise everyone would need to install it!)_

All this means is if we want an `IValueConnector` implementation, then it'd either need to be in a separate assembly/library, or added to the [Umbraco Deploy Contrib](https://github.com/umbraco/Umbraco.Deploy.Contrib) library.

In the meantime, the `IDataTypeConfigurationConnector` implementation in this PR will at least be a step-forwards support for Umbraco Deploy.