### PR TITLE
fix: hide tabs that are now empty

### DIFF
--- a/src/AdminOnlyProperty/AdminOnlyPropertySendingContentNotificationHandler.cs
+++ b/src/AdminOnlyProperty/AdminOnlyPropertySendingContentNotificationHandler.cs
@@ -71,6 +71,26 @@ namespace Umbraco.Community.AdminOnlyProperty
                             tab.Type = string.Empty;
                         }
                     }
+
+                    // if a Tab has only Groups and all the properties in those Groups
+                    // are now hidden we should hide the Tab too
+                    foreach (var tab in variant.Tabs.Where(t => t.Type == "Tab"))
+                    {
+                        if (tab?.Properties?.Any() == true)
+                        {
+                            continue;
+                        }
+
+                        // Groups in this Tab will have aliases that start with this Tab's alias/
+                        if (variant.Tabs.Any(t => t.Type == "Group" && t.Alias?.StartsWith(tab?.Alias + "/") == true) == true)
+                        {
+                            continue;
+                        }
+
+                        // this Tab must have no properties, and no groups to show
+                        // so set Type as Empty so doesn't display
+                        tab.Type = string.Empty;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Issue #14 was raised explaining that a Tab which had only Groups (i.e. no direct properties) was being incorrectly hidden. I've fixed that bug in commit bc965b1.

But now, if a Tab has only Groups and all the properties in those Groups are being hidden for this user, then the Groups are correctly hidden BUT the Tab is still being displayed (despite the Tab having no contents).

This pull request is the code that I've added to fix the problem.

@leekelleher do have any thoughts on the code I've added in this PR to fix this? There is now a test site in this repository with a 'Groups and Tabs' content node that I used to replicate the issue, and confirm that this code does fix the problem. But as this is the first time that I've realised that Tabs and Groups are in the same collection (with a 'Type' property to differentiate), I'd appreciate a second opinion if you have the time please!