### PR TITLE
PR for Umbraco 13.0.1 and .net 8 support.

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,9 +1,3 @@
-# NOTE FOR PR:
-This is a fork for Umbraco 13.0.1 and .net 8 support.
-It was missing implementation of members from Umbraco.Cms.Core.Deploy.IDataTypeConfigurationConnector - Umbraco has added IContextCache contextCache.
-This implementation simply reroute the calls to the existing methods - not implementing the cache layer.
-
-
 # Admin Only Property Editor for Umbraco
 
 [![Downloads](https://img.shields.io/nuget/dt/Our.Umbraco.Community.AdminOnlyProperty?color=cc9900)](https://www.nuget.org/packages/Our.Umbraco.Community.AdminOnlyProperty/)

--- a/.github/README.md
+++ b/.github/README.md
@@ -1,3 +1,9 @@
+# NOTE FOR PR:
+This is a fork for Umbraco 13.0.1 and .net 8 support.
+It was missing implementation of members from Umbraco.Cms.Core.Deploy.IDataTypeConfigurationConnector - Umbraco has added IContextCache contextCache.
+This implementation simply reroute the calls to the existing methods - not implementing the cache layer.
+
+
 # Admin Only Property Editor for Umbraco
 
 [![Downloads](https://img.shields.io/nuget/dt/Our.Umbraco.Community.AdminOnlyProperty?color=cc9900)](https://www.nuget.org/packages/Our.Umbraco.Community.AdminOnlyProperty/)

--- a/src/AdminOnlyProperty/AdminOnlyProperty.csproj
+++ b/src/AdminOnlyProperty/AdminOnlyProperty.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
-
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <StaticWebAssetBasePath>/</StaticWebAssetBasePath>
@@ -34,7 +33,12 @@
     </None>
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="Umbraco.Cms.Core" Version="10.2.0" />
+    <PackageReference Include="Umbraco.Cms.Web.BackOffice" Version="10.2.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Umbraco.Cms.Core" Version="13.0.1" />
     <PackageReference Include="Umbraco.Cms.Web.BackOffice" Version="13.0.1" />
   </ItemGroup>

--- a/src/AdminOnlyProperty/AdminOnlyProperty.csproj
+++ b/src/AdminOnlyProperty/AdminOnlyProperty.csproj
@@ -8,7 +8,7 @@
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageId>Our.Umbraco.Community.AdminOnlyProperty</PackageId>
     <Title>Admin Only Property for Umbraco</Title>
-    <Version>1.1.3</Version>
+    <Version>1.1.4-beta01</Version>
     <Authors>Lotte Pitcher</Authors>
     <Product>Umbraco.Community.AdminOnlyProperty</Product>
     <Description>Restrict a property on a document type by user group(s). If the editor is unauthorised the property will not be shown.</Description>

--- a/src/AdminOnlyProperty/AdminOnlyProperty.csproj
+++ b/src/AdminOnlyProperty/AdminOnlyProperty.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <StaticWebAssetBasePath>/</StaticWebAssetBasePath>
@@ -35,8 +35,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Umbraco.Cms.Core" Version="10.2.0" />
-    <PackageReference Include="Umbraco.Cms.Web.BackOffice" Version="10.2.0" />
+    <PackageReference Include="Umbraco.Cms.Core" Version="13.0.1" />
+    <PackageReference Include="Umbraco.Cms.Web.BackOffice" Version="13.0.1" />
   </ItemGroup>
 
 </Project>

--- a/src/AdminOnlyProperty/AdminOnlyProperty.csproj
+++ b/src/AdminOnlyProperty/AdminOnlyProperty.csproj
@@ -8,7 +8,7 @@
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageId>Our.Umbraco.Community.AdminOnlyProperty</PackageId>
     <Title>Admin Only Property for Umbraco</Title>
-    <Version>1.1.4-beta01</Version>
+    <Version>1.1.3</Version>
     <Authors>Lotte Pitcher</Authors>
     <Product>Umbraco.Community.AdminOnlyProperty</Product>
     <Description>Restrict a property on a document type by user group(s). If the editor is unauthorised the property will not be shown.</Description>

--- a/src/AdminOnlyProperty/AdminOnlyPropertyConfigurationConnector.cs
+++ b/src/AdminOnlyProperty/AdminOnlyPropertyConfigurationConnector.cs
@@ -9,12 +9,14 @@ namespace Umbraco.Community.AdminOnlyProperty
     internal sealed class AdminOnlyPropertyConfigurationConnector : IDataTypeConfigurationConnector
     {
         private readonly IConfigurationEditorJsonSerializer _configurationEditorJsonSerializer;
-        
+
+#if NET8_0
+
         public string? ToArtifact(IDataType dataType, ICollection<ArtifactDependency> dependencies, IContextCache contextCache)
         {
             return ToArtifact(dataType, dependencies);
         }
-
+#endif
         public string? ToArtifact(IDataType dataType, ICollection<ArtifactDependency> dependencies)
         {
             if (dataType.Configuration is Dictionary<string, object> config &&
@@ -27,12 +29,13 @@ namespace Umbraco.Community.AdminOnlyProperty
 
             return ConfigurationEditor.ToDatabase(dataType.Configuration, _configurationEditorJsonSerializer);
         }
-        
+
+#if NET8_0
         public object? FromArtifact(IDataType dataType, string? configuration, IContextCache contextCache)
         {
             return FromArtifact(dataType, configuration);
         }
-
+#endif
         public object? FromArtifact(IDataType dataType, string? configuration)
         {
             var dataTypeConfigurationEditor = dataType.Editor?.GetConfigurationEditor();

--- a/src/AdminOnlyProperty/AdminOnlyPropertyConfigurationConnector.cs
+++ b/src/AdminOnlyProperty/AdminOnlyPropertyConfigurationConnector.cs
@@ -9,18 +9,10 @@ namespace Umbraco.Community.AdminOnlyProperty
     internal sealed class AdminOnlyPropertyConfigurationConnector : IDataTypeConfigurationConnector
     {
         private readonly IConfigurationEditorJsonSerializer _configurationEditorJsonSerializer;
-
-        public IEnumerable<string> PropertyEditorAliases => new[] { AdminOnlyPropertyDataEditor.DataEditorAlias };
-
-        public AdminOnlyPropertyConfigurationConnector(IConfigurationEditorJsonSerializer configurationEditorJsonSerializer)
+        
+        public string? ToArtifact(IDataType dataType, ICollection<ArtifactDependency> dependencies, IContextCache contextCache)
         {
-            _configurationEditorJsonSerializer = configurationEditorJsonSerializer;
-        }
-
-        public object? FromArtifact(IDataType dataType, string? configuration)
-        {
-            var dataTypeConfigurationEditor = dataType.Editor?.GetConfigurationEditor();
-            return dataTypeConfigurationEditor?.FromDatabase(configuration, _configurationEditorJsonSerializer);
+            return ToArtifact(dataType, dependencies);
         }
 
         public string? ToArtifact(IDataType dataType, ICollection<ArtifactDependency> dependencies)
@@ -34,6 +26,24 @@ namespace Umbraco.Community.AdminOnlyProperty
             }
 
             return ConfigurationEditor.ToDatabase(dataType.Configuration, _configurationEditorJsonSerializer);
+        }
+        
+        public object? FromArtifact(IDataType dataType, string? configuration, IContextCache contextCache)
+        {
+            return FromArtifact(dataType, configuration);
+        }
+
+        public object? FromArtifact(IDataType dataType, string? configuration)
+        {
+            var dataTypeConfigurationEditor = dataType.Editor?.GetConfigurationEditor();
+            return dataTypeConfigurationEditor?.FromDatabase(configuration, _configurationEditorJsonSerializer);
+        }
+
+        public IEnumerable<string> PropertyEditorAliases => new[] { AdminOnlyPropertyDataEditor.DataEditorAlias };
+
+        public AdminOnlyPropertyConfigurationConnector(IConfigurationEditorJsonSerializer configurationEditorJsonSerializer)
+        {
+            _configurationEditorJsonSerializer = configurationEditorJsonSerializer;
         }
     }
 }


### PR DESCRIPTION
This is a PR for Umbraco 13.0.1 and .net 8 support.
It was **missing implementation** of members from **Umbraco.Cms.Core.Deploy.IDataTypeConfigurationConnector** - Umbraco has **added IContextCache contextCache**.

This implementation **simply reroute** the calls to the **existing methods** - not implementing the cache layer.

It also **bumps dependency versions** to **Umbraco 13.0.1** and **.net8** due to dependencies - maybe we should use compilerdirectives to keep compatibility with older versions?